### PR TITLE
feat: implement UK Open Banking Payment Initiation API for domestic p…

### DIFF
--- a/payment-initiation-implementation-plan.md
+++ b/payment-initiation-implementation-plan.md
@@ -1,0 +1,233 @@
+# Implementation Plan for Tyk-Bank Payment Initiation API Microservice
+
+## Overview
+
+The payment-initiation API microservice will implement the UK Open Banking Payment Initiation API specification, focusing on domestic payments. It will follow the same architectural pattern as the existing account-information API microservice, using Express.js with TypeScript.
+
+## Architecture
+
+```mermaid
+graph TD
+    Client[Client] --> |HTTP Requests| Server[Express Server]
+    Server --> |Routes| Routes[Payment Routes]
+    Routes --> |Controllers| Controllers[Payment Controllers]
+    Controllers --> |Data Access| DataLayer[Data Layer]
+    DataLayer --> |In-Memory Storage| Models[Payment Models]
+```
+
+## Directory Structure
+
+The new microservice will follow the same structure as the account-information API:
+
+```
+tyk-bank/
+└── src/
+    └── uk/
+        ├── account-information/ (existing)
+        └── payment-initiation/ (new)
+            ├── server.ts
+            ├── controllers/
+            │   ├── consents.ts
+            │   └── payments.ts
+            ├── data/
+            │   ├── consents.ts
+            │   └── payments.ts
+            ├── models/
+            │   ├── consent.ts
+            │   └── payment.ts
+            └── routes/
+                ├── consents.ts
+                └── payments.ts
+```
+
+## Implementation Steps
+
+### 1. Create Basic Server Structure
+
+1. Create a new server.ts file for the payment-initiation API
+2. Set up Express with necessary middleware (cors, json parsing, logging)
+3. Configure the server to run on a different port than the account-information API (e.g., 3002)
+4. Add health check endpoint and error handling middleware
+
+### 2. Define Data Models
+
+1. Create model definitions for:
+   - Payment consent (OBWriteDomesticConsent4)
+   - Payment (OBWriteDomestic2)
+   - Payment response (OBWriteDomesticResponse5)
+   - Enums for payment status and other required types
+
+### 3. Implement Data Layer
+
+1. Create in-memory storage for payment consents and payments
+2. Implement CRUD operations for payment consents and payments
+3. Add sample data for testing
+
+### 4. Create Controllers
+
+1. Implement controllers for:
+   - Creating payment consents
+   - Retrieving payment consents
+   - Creating payments
+   - Retrieving payments
+   - Retrieving payment details
+
+### 5. Set Up Routes
+
+1. Define routes for:
+   - `/domestic-payment-consents` (POST, GET)
+   - `/domestic-payment-consents/{ConsentId}` (GET)
+   - `/domestic-payment-consents/{ConsentId}/funds-confirmation` (GET)
+   - `/domestic-payments` (POST)
+   - `/domestic-payments/{DomesticPaymentId}` (GET)
+   - `/domestic-payments/{DomesticPaymentId}/payment-details` (GET)
+
+### 6. Update Package.json
+
+1. Add new scripts for:
+   - Building the payment-initiation API
+   - Running the payment-initiation API in development mode
+   - Running both APIs simultaneously
+
+### 7. Testing
+
+1. Test all endpoints using tools like Postman or curl
+2. Verify responses match the OpenAPI specification
+
+## Detailed Component Specifications
+
+### Models
+
+#### Payment Consent Model
+
+```typescript
+// Key elements of the consent model
+export enum ConsentStatus {
+  AUTHORISED = 'Authorised',
+  AWAITING_AUTHORISATION = 'AwaitingAuthorisation',
+  CONSUMED = 'Consumed',
+  REJECTED = 'Rejected',
+  REVOKED = 'Revoked',
+  EXPIRED = 'Expired'
+}
+
+export interface DomesticPaymentConsent {
+  ConsentId: string;
+  CreationDateTime: string;
+  Status: ConsentStatus;
+  StatusUpdateDateTime: string;
+  Initiation: {
+    InstructionIdentification: string;
+    EndToEndIdentification: string;
+    InstructedAmount: {
+      Amount: string;
+      Currency: string;
+    };
+    CreditorAccount: {
+      SchemeName: string;
+      Identification: string;
+      Name: string;
+      SecondaryIdentification?: string;
+    };
+    // Other fields as per spec
+  };
+  // Other fields as per spec
+}
+```
+
+#### Payment Model
+
+```typescript
+// Key elements of the payment model
+export enum PaymentStatus {
+  PENDING = 'Pending',
+  ACCEPTED_SETTLEMENT_IN_PROCESS = 'AcceptedSettlementInProcess',
+  ACCEPTED_SETTLEMENT_COMPLETED = 'AcceptedSettlementCompleted',
+  REJECTED = 'Rejected',
+  // Other statuses as per spec
+}
+
+export interface DomesticPayment {
+  DomesticPaymentId: string;
+  ConsentId: string;
+  CreationDateTime: string;
+  Status: PaymentStatus;
+  StatusUpdateDateTime: string;
+  Initiation: {
+    // Same structure as in consent
+  };
+  // Other fields as per spec
+}
+```
+
+### Data Layer
+
+The data layer will use in-memory arrays to store payment consents and payments, similar to the account-information API:
+
+```typescript
+// Sample implementation for consents data layer
+export const paymentConsents: DomesticPaymentConsent[] = [
+  // Sample data
+];
+
+export const createPaymentConsent = (consentData: any): DomesticPaymentConsent => {
+  // Implementation
+};
+
+export const getPaymentConsentById = (consentId: string): DomesticPaymentConsent | undefined => {
+  // Implementation
+};
+
+// Similar functions for payments
+```
+
+### Controllers
+
+Controllers will handle the business logic for each endpoint:
+
+```typescript
+// Sample controller for creating payment consent
+export const createDomesticPaymentConsent = (req: Request, res: Response) => {
+  try {
+    // Validate request
+    // Create consent
+    // Return response
+  } catch (error) {
+    // Handle error
+  }
+};
+
+// Similar controllers for other endpoints
+```
+
+### Routes
+
+Routes will map HTTP endpoints to controllers:
+
+```typescript
+// Sample routes for payment consents
+const router = Router();
+
+router.post('/', createDomesticPaymentConsent);
+router.get('/:consentId', getDomesticPaymentConsent);
+
+export default router;
+```
+
+## Integration with Existing Code
+
+The new payment-initiation API will be a separate microservice running alongside the existing account-information API. We'll need to:
+
+1. Create a new server.ts file for the payment-initiation API
+2. Update package.json to include scripts for running both services
+3. Consider updating the Docker configuration to support both services
+
+## Timeline Estimate
+
+1. Setting up project structure: 1 hour
+2. Implementing models and data layer: 3 hours
+3. Implementing controllers and routes: 4 hours
+4. Testing and debugging: 2 hours
+5. Documentation: 1 hour
+
+Total estimated time: ~11 hours of development work

--- a/tyk-bank/Dockerfile
+++ b/tyk-bank/Dockerfile
@@ -19,17 +19,20 @@ RUN npm run build
 ARG SERVICE=uk-account-information
 ENV SERVICE=${SERVICE}
 
-# Expose port
-EXPOSE 3001
+# Expose ports
+EXPOSE 3001 3002
 
 # Set environment variables
 ENV NODE_ENV=production
+# Default port, will be overridden by docker-compose.yml
 ENV PORT=3001
 
 # Run the specified service
 CMD if [ "$SERVICE" = "uk-account-information" ]; then \
       node dist/uk/account-information/server.js; \
     elif [ "$SERVICE" = "uk-payment-initiation" ]; then \
+      # Override default port if not set in environment
+      [ -z "$PORT" ] && export PORT=3002; \
       node dist/uk/payment-initiation/server.js; \
     elif [ "$SERVICE" = "brazil-account-information" ]; then \
       node dist/brazil/account-information/server.js; \

--- a/tyk-bank/README.md
+++ b/tyk-bank/README.md
@@ -8,9 +8,10 @@ This project provides a mock implementation of Open Banking APIs from multiple c
 
 **Currently Implemented:**
 - UK Open Banking Account Information API
+- UK Open Banking Payment Initiation API (Domestic Payments only)
 
 **Planned for Future:**
-- UK Open Banking Payment Initiation API
+- UK Open Banking Payment Initiation API (Additional payment types)
 - Brazil Open Banking APIs
 - Additional country implementations
 
@@ -19,6 +20,8 @@ The mock bank provides endpoints for:
 - Account Balances
 - Account Transactions
 - Account Access Consents
+- Domestic Payment Consents
+- Domestic Payments
 
 ## Project Structure
 
@@ -30,7 +33,7 @@ tyk-bank/
 │   ├── common/                      # Shared utilities and types
 │   ├── uk/                          # UK Open Banking
 │   │   ├── account-information/     # Account Information API
-│   │   └── payment-initiation/      # Payment Initiation API (future)
+│   │   └── payment-initiation/      # Payment Initiation API
 │   └── brazil/                      # Brazil Open Banking (future)
 └── tests/                           # Test files
 ```
@@ -65,16 +68,33 @@ tyk-bank/
 
 #### Using Node.js
 
-Start the server:
+Start the Account Information API server:
 ```
-npm start
+npm run start:account
 ```
 
-The server will start on port 3001 by default. You can change this by setting the `PORT` environment variable.
+Start the Payment Initiation API server:
+```
+npm run start:payment
+```
+
+Start both servers concurrently:
+```
+npm run dev:all
+```
+
+The Account Information API will start on port 3001 and the Payment Initiation API on port 3002 by default. You can change this by setting the `PORT` environment variable.
 
 For development with auto-reload:
 ```
-npm run dev
+# Account Information API
+npm run dev:account
+
+# Payment Initiation API
+npm run dev:payment
+
+# Both APIs concurrently
+npm run dev:all
 ```
 
 #### Using Docker
@@ -115,9 +135,10 @@ The project is structured as a collection of microservices, each representing a 
 - Provides account information, balances, and transactions
 - Manages account access consents
 
-#### Payment Initiation API (Port 3002, future)
-- Will handle payment initiation requests
-- Will manage payment consents
+#### Payment Initiation API (Port 3002)
+- Handles domestic payment initiation requests
+- Manages domestic payment consents
+- Provides funds confirmation
 
 ### Brazil Open Banking (future)
 
@@ -141,13 +162,24 @@ The project is structured as a collection of microservices, each representing a 
 - `GET /balances` - Get all balances
 - `GET /transactions` - Get all transactions
 
+### UK Open Banking - Payment Initiation
+
+- `POST /domestic-payment-consents` - Create a new domestic payment consent
+- `GET /domestic-payment-consents/{ConsentId}` - Get domestic payment consent details
+- `GET /domestic-payment-consents/{ConsentId}/funds-confirmation` - Check funds availability
+- `POST /domestic-payments` - Create a new domestic payment
+- `GET /domestic-payments/{DomesticPaymentId}` - Get domestic payment details
+- `GET /domestic-payments/{DomesticPaymentId}/payment-details` - Get additional payment details
+
 ## Mock Data
 
 The mock bank comes pre-populated with sample data:
 - 5 accounts (current, savings, credit card, business, and euro accounts)
 - Balances for each account
 - Transactions for each account
-- Sample consents
+- Sample account access consents
+- Sample domestic payment consents
+- Sample domestic payments
 
 ## Security
 

--- a/tyk-bank/docker-compose.yml
+++ b/tyk-bank/docker-compose.yml
@@ -22,26 +22,26 @@ services:
       retries: 3
       start_period: 10s
 
-  # UK Open Banking - Payment Initiation API (uncomment when implemented)
-  # uk-payment-initiation:
-  #   build:
-  #     context: .
-  #     dockerfile: Dockerfile
-  #     args:
-  #       - SERVICE=uk-payment-initiation
-  #   ports:
-  #     - "3002:3001"
-  #   environment:
-  #     - NODE_ENV=production
-  #     - PORT=3001
-  #     - SERVICE=uk-payment-initiation
-  #   restart: unless-stopped
-  #   healthcheck:
-  #     test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3001/health"]
-  #     interval: 30s
-  #     timeout: 10s
-  #     retries: 3
-  #     start_period: 10s
+  # UK Open Banking - Payment Initiation API
+  uk-payment-initiation:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - SERVICE=uk-payment-initiation
+    ports:
+      - "3002:3002"
+    environment:
+      - NODE_ENV=production
+      - PORT=3002
+      - SERVICE=uk-payment-initiation
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3002/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
 
   # Brazil Open Banking - Account Information API (uncomment when implemented)
   # brazil-account-information:
@@ -74,3 +74,4 @@ services:
   #     - API_URL=http://localhost:3001/  # Currently no OpenAPI spec endpoint exists
   #   depends_on:
   #     - uk-account-information
+  #     - uk-payment-initiation

--- a/tyk-bank/package.json
+++ b/tyk-bank/package.json
@@ -5,8 +5,13 @@
   "main": "dist/uk/account-information/server.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/uk/account-information/server.js",
-    "dev": "ts-node-dev --respawn --transpile-only src/uk/account-information/server.ts",
+    "start:account": "node dist/uk/account-information/server.js",
+    "start:payment": "node dist/uk/payment-initiation/server.js",
+    "start": "npm run start:account",
+    "dev:account": "ts-node-dev --respawn --transpile-only src/uk/account-information/server.ts",
+    "dev:payment": "ts-node-dev --respawn --transpile-only src/uk/payment-initiation/server.ts",
+    "dev": "npm run dev:account",
+    "dev:all": "concurrently \"npm run dev:account\" \"npm run dev:payment\"",
     "test": "jest",
     "lint": "eslint . --ext .ts"
   },
@@ -38,6 +43,7 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "concurrently": "^8.2.2"
   }
 }

--- a/tyk-bank/src/uk/payment-initiation/controllers/consents.ts
+++ b/tyk-bank/src/uk/payment-initiation/controllers/consents.ts
@@ -1,0 +1,191 @@
+import { Request, Response } from 'express';
+import { 
+  createPaymentConsent, 
+  getPaymentConsentById, 
+  checkFundsAvailability,
+  updatePaymentConsentStatus
+} from '../data/consents';
+import { 
+  DomesticPaymentConsentRequest, 
+  ConsentStatus 
+} from '../models/consent';
+import { Links, Meta } from '../../../common/types/common';
+
+/**
+ * Create a new domestic payment consent
+ * @param req Express request
+ * @param res Express response
+ */
+export const createDomesticPaymentConsent = (req: Request, res: Response) => {
+  try {
+    const consentRequest = req.body as DomesticPaymentConsentRequest;
+    
+    // Validate request body
+    if (!consentRequest?.Data?.Initiation) {
+      return res.status(400).json({
+        ErrorCode: 'InvalidRequest',
+        ErrorMessage: 'Initiation object is required'
+      });
+    }
+    
+    const { Initiation } = consentRequest.Data;
+    
+    // Validate required fields
+    if (!Initiation.InstructionIdentification) {
+      return res.status(400).json({
+        ErrorCode: 'InvalidRequest',
+        ErrorMessage: 'InstructionIdentification is required'
+      });
+    }
+    
+    if (!Initiation.EndToEndIdentification) {
+      return res.status(400).json({
+        ErrorCode: 'InvalidRequest',
+        ErrorMessage: 'EndToEndIdentification is required'
+      });
+    }
+    
+    if (!Initiation.InstructedAmount || !Initiation.InstructedAmount.Amount || !Initiation.InstructedAmount.Currency) {
+      return res.status(400).json({
+        ErrorCode: 'InvalidRequest',
+        ErrorMessage: 'InstructedAmount with Amount and Currency is required'
+      });
+    }
+    
+    if (!Initiation.CreditorAccount || !Initiation.CreditorAccount.SchemeName || 
+        !Initiation.CreditorAccount.Identification || !Initiation.CreditorAccount.Name) {
+      return res.status(400).json({
+        ErrorCode: 'InvalidRequest',
+        ErrorMessage: 'CreditorAccount with SchemeName, Identification, and Name is required'
+      });
+    }
+    
+    // Create new consent
+    const newConsent = createPaymentConsent(
+      Initiation,
+      consentRequest.Risk || {}
+    );
+    
+    // For demo purposes, automatically authorize the consent
+    // In a real implementation, this would require user authorization
+    setTimeout(() => {
+      updatePaymentConsentStatus(newConsent.ConsentId, ConsentStatus.AUTHORISED);
+    }, 1000);
+    
+    const response = {
+      Data: {
+        ConsentId: newConsent.ConsentId,
+        CreationDateTime: newConsent.CreationDateTime,
+        Status: newConsent.Status,
+        StatusUpdateDateTime: newConsent.StatusUpdateDateTime,
+        Initiation: newConsent.Initiation,
+        ExpirationDateTime: newConsent.ExpirationDateTime
+      },
+      Risk: newConsent.Risk,
+      Links: {
+        Self: `${req.protocol}://${req.get('host')}${req.originalUrl}/${newConsent.ConsentId}`
+      } as Links,
+      Meta: {
+        TotalPages: 1
+      } as Meta
+    };
+    
+    res.status(201).json(response);
+  } catch (error) {
+    console.error('Error creating domestic payment consent:', error);
+    res.status(500).json({
+      ErrorCode: 'InternalServerError',
+      ErrorMessage: 'An internal server error occurred'
+    });
+  }
+};
+
+/**
+ * Get domestic payment consent by ID
+ * @param req Express request
+ * @param res Express response
+ */
+export const getDomesticPaymentConsent = (req: Request, res: Response) => {
+  try {
+    const { consentId } = req.params;
+    const consent = getPaymentConsentById(consentId);
+    
+    if (!consent) {
+      return res.status(404).json({
+        ErrorCode: 'ResourceNotFound',
+        ErrorMessage: `Domestic payment consent with ID ${consentId} not found`
+      });
+    }
+    
+    const response = {
+      Data: {
+        ConsentId: consent.ConsentId,
+        CreationDateTime: consent.CreationDateTime,
+        Status: consent.Status,
+        StatusUpdateDateTime: consent.StatusUpdateDateTime,
+        Initiation: consent.Initiation,
+        ExpirationDateTime: consent.ExpirationDateTime
+      },
+      Risk: consent.Risk,
+      Links: {
+        Self: `${req.protocol}://${req.get('host')}${req.originalUrl}`
+      } as Links,
+      Meta: {
+        TotalPages: 1
+      } as Meta
+    };
+    
+    res.status(200).json(response);
+  } catch (error) {
+    console.error('Error getting domestic payment consent by ID:', error);
+    res.status(500).json({
+      ErrorCode: 'InternalServerError',
+      ErrorMessage: 'An internal server error occurred'
+    });
+  }
+};
+
+/**
+ * Get funds confirmation for a domestic payment consent
+ * @param req Express request
+ * @param res Express response
+ */
+export const getDomesticPaymentConsentFundsConfirmation = (req: Request, res: Response) => {
+  try {
+    const { consentId } = req.params;
+    const consent = getPaymentConsentById(consentId);
+    
+    if (!consent) {
+      return res.status(404).json({
+        ErrorCode: 'ResourceNotFound',
+        ErrorMessage: `Domestic payment consent with ID ${consentId} not found`
+      });
+    }
+    
+    // Check funds availability
+    const fundsAvailable = checkFundsAvailability(consentId);
+    
+    const response = {
+      Data: {
+        FundsAvailableResult: {
+          FundsAvailable: fundsAvailable,
+          FundsAvailableDateTime: new Date().toISOString()
+        }
+      },
+      Links: {
+        Self: `${req.protocol}://${req.get('host')}${req.originalUrl}`
+      } as Links,
+      Meta: {
+        TotalPages: 1
+      } as Meta
+    };
+    
+    res.status(200).json(response);
+  } catch (error) {
+    console.error('Error checking funds confirmation:', error);
+    res.status(500).json({
+      ErrorCode: 'InternalServerError',
+      ErrorMessage: 'An internal server error occurred'
+    });
+  }
+};

--- a/tyk-bank/src/uk/payment-initiation/controllers/payments.ts
+++ b/tyk-bank/src/uk/payment-initiation/controllers/payments.ts
@@ -1,0 +1,175 @@
+import { Request, Response } from 'express';
+import { 
+  createPayment, 
+  getPaymentById, 
+  getPaymentDetails 
+} from '../data/payments';
+import { getPaymentConsentById } from '../data/consents';
+import { DomesticPaymentRequest } from '../models/payment';
+import { ConsentStatus } from '../models/consent';
+import { Links, Meta } from '../../../common/types/common';
+
+/**
+ * Create a new domestic payment
+ * @param req Express request
+ * @param res Express response
+ */
+export const createDomesticPayment = (req: Request, res: Response) => {
+  try {
+    const paymentRequest = req.body as DomesticPaymentRequest;
+    
+    // Validate request body
+    if (!paymentRequest?.Data?.ConsentId) {
+      return res.status(400).json({
+        ErrorCode: 'InvalidRequest',
+        ErrorMessage: 'ConsentId is required'
+      });
+    }
+    
+    const { ConsentId } = paymentRequest.Data;
+    
+    // Check if consent exists
+    const consent = getPaymentConsentById(ConsentId);
+    if (!consent) {
+      return res.status(400).json({
+        ErrorCode: 'InvalidConsentId',
+        ErrorMessage: `Consent with ID ${ConsentId} not found`
+      });
+    }
+    
+    // Check if consent is in the right state
+    if (consent.Status !== ConsentStatus.AUTHORISED) {
+      return res.status(400).json({
+        ErrorCode: 'InvalidConsentStatus',
+        ErrorMessage: `Consent with ID ${ConsentId} has status ${consent.Status}, expected ${ConsentStatus.AUTHORISED}`
+      });
+    }
+    
+    // Create new payment
+    const newPayment = createPayment(ConsentId);
+    
+    if (!newPayment) {
+      return res.status(400).json({
+        ErrorCode: 'PaymentCreationFailed',
+        ErrorMessage: 'Failed to create payment'
+      });
+    }
+    
+    const response = {
+      Data: {
+        DomesticPaymentId: newPayment.DomesticPaymentId,
+        ConsentId: newPayment.ConsentId,
+        CreationDateTime: newPayment.CreationDateTime,
+        Status: newPayment.Status,
+        StatusUpdateDateTime: newPayment.StatusUpdateDateTime,
+        ExpectedExecutionDateTime: newPayment.ExpectedExecutionDateTime,
+        ExpectedSettlementDateTime: newPayment.ExpectedSettlementDateTime,
+        Initiation: newPayment.Initiation
+      },
+      Links: {
+        Self: `${req.protocol}://${req.get('host')}${req.originalUrl}/${newPayment.DomesticPaymentId}`
+      } as Links,
+      Meta: {
+        TotalPages: 1
+      } as Meta
+    };
+    
+    res.status(201).json(response);
+  } catch (error) {
+    console.error('Error creating domestic payment:', error);
+    res.status(500).json({
+      ErrorCode: 'InternalServerError',
+      ErrorMessage: 'An internal server error occurred'
+    });
+  }
+};
+
+/**
+ * Get domestic payment by ID
+ * @param req Express request
+ * @param res Express response
+ */
+export const getDomesticPayment = (req: Request, res: Response) => {
+  try {
+    const { paymentId } = req.params;
+    const payment = getPaymentById(paymentId);
+    
+    if (!payment) {
+      return res.status(404).json({
+        ErrorCode: 'ResourceNotFound',
+        ErrorMessage: `Domestic payment with ID ${paymentId} not found`
+      });
+    }
+    
+    const response = {
+      Data: {
+        DomesticPaymentId: payment.DomesticPaymentId,
+        ConsentId: payment.ConsentId,
+        CreationDateTime: payment.CreationDateTime,
+        Status: payment.Status,
+        StatusUpdateDateTime: payment.StatusUpdateDateTime,
+        ExpectedExecutionDateTime: payment.ExpectedExecutionDateTime,
+        ExpectedSettlementDateTime: payment.ExpectedSettlementDateTime,
+        Charges: payment.Charges,
+        Initiation: payment.Initiation,
+        MultiAuthorisation: payment.MultiAuthorisation
+      },
+      Links: {
+        Self: `${req.protocol}://${req.get('host')}${req.originalUrl}`
+      } as Links,
+      Meta: {
+        TotalPages: 1
+      } as Meta
+    };
+    
+    res.status(200).json(response);
+  } catch (error) {
+    console.error('Error getting domestic payment by ID:', error);
+    res.status(500).json({
+      ErrorCode: 'InternalServerError',
+      ErrorMessage: 'An internal server error occurred'
+    });
+  }
+};
+
+/**
+ * Get domestic payment details
+ * @param req Express request
+ * @param res Express response
+ */
+export const getDomesticPaymentDetails = (req: Request, res: Response) => {
+  try {
+    const { paymentId } = req.params;
+    const paymentDetails = getPaymentDetails(paymentId);
+    
+    if (!paymentDetails) {
+      return res.status(404).json({
+        ErrorCode: 'ResourceNotFound',
+        ErrorMessage: `Domestic payment with ID ${paymentId} not found`
+      });
+    }
+    
+    const response = {
+      Data: {
+        PaymentStatus: paymentDetails.PaymentStatus,
+        PaymentStatusUpdateDateTime: paymentDetails.PaymentStatusUpdateDateTime,
+        ExpectedExecutionDateTime: paymentDetails.ExpectedExecutionDateTime,
+        ExpectedSettlementDateTime: paymentDetails.ExpectedSettlementDateTime
+      },
+      Links: {
+        Self: `${req.protocol}://${req.get('host')}${req.originalUrl}`
+      } as Links,
+      Meta: {
+        TotalPages: 1
+      } as Meta
+    };
+    
+    res.status(200).json(response);
+  } catch (error) {
+    console.error('Error getting domestic payment details:', error);
+    res.status(500).json({
+      ErrorCode: 'InternalServerError',
+      ErrorMessage: 'An internal server error occurred'
+    });
+  }
+};

--- a/tyk-bank/src/uk/payment-initiation/data/consents.ts
+++ b/tyk-bank/src/uk/payment-initiation/data/consents.ts
@@ -1,0 +1,139 @@
+import { v4 as uuidv4 } from 'uuid';
+import { 
+  DomesticPaymentConsent, 
+  ConsentStatus, 
+  DomesticPaymentInitiation 
+} from '../models/consent';
+
+/**
+ * Mock payment consents data
+ */
+export const paymentConsents: DomesticPaymentConsent[] = [
+  {
+    ConsentId: 'pcon-001',
+    CreationDateTime: '2023-05-01T10:00:00+00:00',
+    Status: ConsentStatus.AUTHORISED,
+    StatusUpdateDateTime: '2023-05-01T10:05:00+00:00',
+    Initiation: {
+      InstructionIdentification: 'ACME412',
+      EndToEndIdentification: 'FRESCO.21302.GFX.20',
+      InstructedAmount: {
+        Amount: '165.88',
+        Currency: 'GBP'
+      },
+      CreditorAccount: {
+        SchemeName: 'UK.OBIE.SortCodeAccountNumber',
+        Identification: '08080021325698',
+        Name: 'ACME Inc',
+        SecondaryIdentification: '0002'
+      },
+      RemittanceInformation: {
+        Reference: 'FRESCO-101',
+        Unstructured: 'Internal ops code 5120101'
+      }
+    },
+    Risk: {}
+  },
+  {
+    ConsentId: 'pcon-002',
+    CreationDateTime: '2023-05-02T14:30:00+00:00',
+    Status: ConsentStatus.AWAITING_AUTHORISATION,
+    StatusUpdateDateTime: '2023-05-02T14:30:00+00:00',
+    Initiation: {
+      InstructionIdentification: 'PAYREF-45321',
+      EndToEndIdentification: 'BILLINV-45789',
+      InstructedAmount: {
+        Amount: '256.99',
+        Currency: 'GBP'
+      },
+      CreditorAccount: {
+        SchemeName: 'UK.OBIE.SortCodeAccountNumber',
+        Identification: '20051899712564',
+        Name: 'Merchant XYZ Ltd'
+      },
+      RemittanceInformation: {
+        Reference: 'INV-45789'
+      }
+    },
+    Risk: {}
+  }
+];
+
+/**
+ * Get all payment consents
+ */
+export const getAllPaymentConsents = (): DomesticPaymentConsent[] => {
+  return paymentConsents;
+};
+
+/**
+ * Get payment consent by ID
+ */
+export const getPaymentConsentById = (consentId: string): DomesticPaymentConsent | undefined => {
+  return paymentConsents.find(consent => consent.ConsentId === consentId);
+};
+
+/**
+ * Create a new payment consent
+ */
+export const createPaymentConsent = (
+  initiation: DomesticPaymentInitiation,
+  risk: Record<string, unknown>
+): DomesticPaymentConsent => {
+  const now = new Date().toISOString();
+  const newConsent: DomesticPaymentConsent = {
+    ConsentId: `pcon-${uuidv4().substring(0, 8)}`,
+    CreationDateTime: now,
+    Status: ConsentStatus.AWAITING_AUTHORISATION,
+    StatusUpdateDateTime: now,
+    Initiation: initiation,
+    Risk: risk,
+    ExpirationDateTime: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString() // 24 hours from now
+  };
+  
+  paymentConsents.push(newConsent);
+  return newConsent;
+};
+
+/**
+ * Update payment consent status
+ */
+export const updatePaymentConsentStatus = (consentId: string, status: ConsentStatus): DomesticPaymentConsent | undefined => {
+  const consent = getPaymentConsentById(consentId);
+  
+  if (consent) {
+    consent.Status = status;
+    consent.StatusUpdateDateTime = new Date().toISOString();
+  }
+  
+  return consent;
+};
+
+/**
+ * Delete payment consent
+ */
+export const deletePaymentConsent = (consentId: string): boolean => {
+  const index = paymentConsents.findIndex(consent => consent.ConsentId === consentId);
+  
+  if (index !== -1) {
+    paymentConsents.splice(index, 1);
+    return true;
+  }
+  
+  return false;
+};
+
+/**
+ * Check if funds are available for a payment consent
+ * This is a mock implementation that always returns true for authorized consents
+ */
+export const checkFundsAvailability = (consentId: string): boolean => {
+  const consent = getPaymentConsentById(consentId);
+  
+  if (consent && consent.Status === ConsentStatus.AUTHORISED) {
+    // In a real implementation, this would check if the debtor account has sufficient funds
+    return true;
+  }
+  
+  return false;
+};

--- a/tyk-bank/src/uk/payment-initiation/data/payments.ts
+++ b/tyk-bank/src/uk/payment-initiation/data/payments.ts
@@ -1,0 +1,145 @@
+import { v4 as uuidv4 } from 'uuid';
+import { 
+  DomesticPayment, 
+  PaymentStatus 
+} from '../models/payment';
+import { 
+  getPaymentConsentById, 
+  updatePaymentConsentStatus 
+} from './consents';
+import { ConsentStatus } from '../models/consent';
+
+/**
+ * Mock payments data
+ */
+export const payments: DomesticPayment[] = [
+  {
+    DomesticPaymentId: 'p-001',
+    ConsentId: 'pcon-001',
+    CreationDateTime: '2023-05-01T10:10:00+00:00',
+    Status: PaymentStatus.ACCEPTED_SETTLEMENT_COMPLETED,
+    StatusUpdateDateTime: '2023-05-01T10:15:00+00:00',
+    ExpectedExecutionDateTime: '2023-05-01T10:10:00+00:00',
+    ExpectedSettlementDateTime: '2023-05-01T10:15:00+00:00',
+    Initiation: {
+      InstructionIdentification: 'ACME412',
+      EndToEndIdentification: 'FRESCO.21302.GFX.20',
+      InstructedAmount: {
+        Amount: '165.88',
+        Currency: 'GBP'
+      },
+      CreditorAccount: {
+        SchemeName: 'UK.OBIE.SortCodeAccountNumber',
+        Identification: '08080021325698',
+        Name: 'ACME Inc',
+        SecondaryIdentification: '0002'
+      },
+      RemittanceInformation: {
+        Reference: 'FRESCO-101',
+        Unstructured: 'Internal ops code 5120101'
+      }
+    }
+  }
+];
+
+/**
+ * Get all payments
+ */
+export const getAllPayments = (): DomesticPayment[] => {
+  return payments;
+};
+
+/**
+ * Get payment by ID
+ */
+export const getPaymentById = (paymentId: string): DomesticPayment | undefined => {
+  return payments.find(payment => payment.DomesticPaymentId === paymentId);
+};
+
+/**
+ * Get payments by consent ID
+ */
+export const getPaymentsByConsentId = (consentId: string): DomesticPayment[] => {
+  return payments.filter(payment => payment.ConsentId === consentId);
+};
+
+/**
+ * Create a new payment
+ */
+export const createPayment = (consentId: string): DomesticPayment | undefined => {
+  const consent = getPaymentConsentById(consentId);
+  
+  if (!consent) {
+    return undefined;
+  }
+  
+  // Check if consent is in the right state
+  if (consent.Status !== ConsentStatus.AUTHORISED) {
+    return undefined;
+  }
+  
+  const now = new Date().toISOString();
+  const executionDateTime = now;
+  const settlementDateTime = new Date(Date.now() + 5 * 60 * 1000).toISOString(); // 5 minutes later
+  
+  const newPayment: DomesticPayment = {
+    DomesticPaymentId: `p-${uuidv4().substring(0, 8)}`,
+    ConsentId: consentId,
+    CreationDateTime: now,
+    Status: PaymentStatus.ACCEPTED_SETTLEMENT_IN_PROCESS,
+    StatusUpdateDateTime: now,
+    ExpectedExecutionDateTime: executionDateTime,
+    ExpectedSettlementDateTime: settlementDateTime,
+    Initiation: consent.Initiation
+  };
+  
+  payments.push(newPayment);
+  
+  // Update consent status to CONSUMED
+  updatePaymentConsentStatus(consentId, ConsentStatus.CONSUMED);
+  
+  // In a real implementation, we would initiate the actual payment process here
+  // For this mock implementation, we'll simulate the payment completing after a short delay
+  setTimeout(() => {
+    updatePaymentStatus(newPayment.DomesticPaymentId, PaymentStatus.ACCEPTED_SETTLEMENT_COMPLETED);
+  }, 2000);
+  
+  return newPayment;
+};
+
+/**
+ * Update payment status
+ */
+export const updatePaymentStatus = (paymentId: string, status: PaymentStatus): DomesticPayment | undefined => {
+  const payment = getPaymentById(paymentId);
+  
+  if (payment) {
+    payment.Status = status;
+    payment.StatusUpdateDateTime = new Date().toISOString();
+  }
+  
+  return payment;
+};
+
+/**
+ * Get payment details
+ */
+export const getPaymentDetails = (paymentId: string): {
+  PaymentStatus: PaymentStatus;
+  PaymentStatusUpdateDateTime: string;
+  ExpectedExecutionDateTime?: string;
+  ExpectedSettlementDateTime?: string;
+} | undefined => {
+  const payment = getPaymentById(paymentId);
+  
+  if (!payment) {
+    return undefined;
+  }
+  
+  return {
+    PaymentStatus: payment.Status,
+    PaymentStatusUpdateDateTime: payment.StatusUpdateDateTime,
+    ExpectedExecutionDateTime: payment.ExpectedExecutionDateTime,
+    ExpectedSettlementDateTime: payment.ExpectedSettlementDateTime
+  };
+};

--- a/tyk-bank/src/uk/payment-initiation/models/consent.ts
+++ b/tyk-bank/src/uk/payment-initiation/models/consent.ts
@@ -1,0 +1,107 @@
+import { Links, Meta, ApiResponse } from '../../../common/types/common';
+
+/**
+ * Consent status
+ */
+export enum ConsentStatus {
+  AWAITING_AUTHORISATION = 'AwaitingAuthorisation',
+  AUTHORISED = 'Authorised',
+  CONSUMED = 'Consumed',
+  REJECTED = 'Rejected',
+  REVOKED = 'Revoked',
+  EXPIRED = 'Expired'
+}
+
+/**
+ * Domestic payment consent model
+ */
+export interface DomesticPaymentConsent {
+  ConsentId: string;
+  CreationDateTime: string;
+  Status: ConsentStatus;
+  StatusUpdateDateTime: string;
+  Initiation: DomesticPaymentInitiation;
+  Risk: Record<string, unknown>;
+  ExpirationDateTime?: string;
+}
+
+/**
+ * Domestic payment initiation
+ */
+export interface DomesticPaymentInitiation {
+  InstructionIdentification: string;
+  EndToEndIdentification: string;
+  InstructedAmount: {
+    Amount: string;
+    Currency: string;
+  };
+  DebtorAccount?: {
+    SchemeName: string;
+    Identification: string;
+    Name?: string;
+    SecondaryIdentification?: string;
+  };
+  CreditorAccount: {
+    SchemeName: string;
+    Identification: string;
+    Name: string;
+    SecondaryIdentification?: string;
+  };
+  CreditorPostalAddress?: {
+    AddressType?: string;
+    Department?: string;
+    SubDepartment?: string;
+    StreetName?: string;
+    BuildingNumber?: string;
+    PostCode?: string;
+    TownName?: string;
+    CountrySubDivision?: string;
+    Country?: string;
+    AddressLine?: string[];
+  };
+  RemittanceInformation?: {
+    Unstructured?: string;
+    Reference?: string;
+  };
+}
+
+/**
+ * Domestic payment consent request
+ */
+export interface DomesticPaymentConsentRequest {
+  Data: {
+    Initiation: DomesticPaymentInitiation;
+  };
+  Risk: Record<string, unknown>;
+}
+
+/**
+ * Domestic payment consent response
+ */
+export interface DomesticPaymentConsentResponse {
+  Data: {
+    ConsentId: string;
+    CreationDateTime: string;
+    Status: ConsentStatus;
+    StatusUpdateDateTime: string;
+    Initiation: DomesticPaymentInitiation;
+    ExpirationDateTime?: string;
+  };
+  Risk: Record<string, unknown>;
+  Links: Links;
+  Meta: Meta;
+}
+
+/**
+ * Funds confirmation response
+ */
+export interface FundsConfirmationResponse {
+  Data: {
+    FundsAvailableResult: {
+      FundsAvailable: boolean;
+      FundsAvailableDateTime: string;
+    }
+  };
+  Links: Links;
+  Meta: Meta;
+}

--- a/tyk-bank/src/uk/payment-initiation/models/payment.ts
+++ b/tyk-bank/src/uk/payment-initiation/models/payment.ts
@@ -1,0 +1,113 @@
+import { Links, Meta } from '../../../common/types/common';
+import { DomesticPaymentInitiation } from './consent';
+
+/**
+ * Payment status
+ */
+export enum PaymentStatus {
+  PENDING = 'Pending',
+  REJECTED = 'Rejected',
+  ACCEPTED_SETTLEMENT_IN_PROCESS = 'AcceptedSettlementInProcess',
+  ACCEPTED_SETTLEMENT_COMPLETED = 'AcceptedSettlementCompleted',
+  ACCEPTED_WITHOUT_POSTING = 'AcceptedWithoutPosting',
+  ACCEPTED_CREDIT_SETTLEMENT_COMPLETED = 'AcceptedCreditSettlementCompleted'
+}
+
+/**
+ * Domestic payment model
+ */
+export interface DomesticPayment {
+  DomesticPaymentId: string;
+  ConsentId: string;
+  CreationDateTime: string;
+  Status: PaymentStatus;
+  StatusUpdateDateTime: string;
+  ExpectedExecutionDateTime?: string;
+  ExpectedSettlementDateTime?: string;
+  Charges?: Array<{
+    ChargeBearer: string;
+    Type: string;
+    Amount: {
+      Amount: string;
+      Currency: string;
+    };
+  }>;
+  Initiation: DomesticPaymentInitiation;
+  MultiAuthorisation?: {
+    Status: string;
+    NumberRequired: number;
+    NumberReceived: number;
+    LastUpdateDateTime: string;
+    ExpirationDateTime: string;
+  };
+}
+
+/**
+ * Domestic payment request
+ */
+export interface DomesticPaymentRequest {
+  Data: {
+    ConsentId: string;
+    Initiation: DomesticPaymentInitiation;
+  };
+  Risk: Record<string, unknown>;
+}
+
+/**
+ * Domestic payment response
+ */
+export interface DomesticPaymentResponse {
+  Data: {
+    DomesticPaymentId: string;
+    ConsentId: string;
+    CreationDateTime: string;
+    Status: PaymentStatus;
+    StatusUpdateDateTime: string;
+    ExpectedExecutionDateTime?: string;
+    ExpectedSettlementDateTime?: string;
+    Charges?: Array<{
+      ChargeBearer: string;
+      Type: string;
+      Amount: {
+        Amount: string;
+        Currency: string;
+      };
+    }>;
+    Initiation: DomesticPaymentInitiation;
+    MultiAuthorisation?: {
+      Status: string;
+      NumberRequired: number;
+      NumberReceived: number;
+      LastUpdateDateTime: string;
+      ExpirationDateTime: string;
+    };
+  };
+  Links: Links;
+  Meta: Meta;
+}
+
+/**
+ * Payment details response
+ */
+export interface PaymentDetailsResponse {
+  Data: {
+    PaymentStatus: PaymentStatus;
+    PaymentStatusUpdateDateTime: string;
+    ExpectedExecutionDateTime?: string;
+    ExpectedSettlementDateTime?: string;
+    Charges?: Array<{
+      ChargeBearer: string;
+      Type: string;
+      Amount: {
+        Amount: string;
+        Currency: string;
+      };
+    }>;
+    StatusReason?: {
+      Status: string;
+      Description: string;
+    };
+  };
+  Links: Links;
+  Meta: Meta;
+}

--- a/tyk-bank/src/uk/payment-initiation/routes/consents.ts
+++ b/tyk-bank/src/uk/payment-initiation/routes/consents.ts
@@ -1,0 +1,68 @@
+import { Router } from 'express';
+import { 
+  createDomesticPaymentConsent, 
+  getDomesticPaymentConsent,
+  getDomesticPaymentConsentFundsConfirmation
+} from '../controllers/consents';
+
+const router = Router();
+
+/**
+ * @swagger
+ * /domestic-payment-consents:
+ *   post:
+ *     summary: Create domestic payment consent
+ *     description: Creates a new domestic payment consent
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/DomesticPaymentConsentRequest'
+ *     responses:
+ *       201:
+ *         description: Consent created successfully
+ *       400:
+ *         description: Invalid request
+ */
+router.post('/', createDomesticPaymentConsent);
+
+/**
+ * @swagger
+ * /domestic-payment-consents/{consentId}:
+ *   get:
+ *     summary: Get domestic payment consent
+ *     description: Retrieves domestic payment consent details by ID
+ *     parameters:
+ *       - in: path
+ *         name: consentId
+ *         required: true
+ *         description: ID of the consent to retrieve
+ *     responses:
+ *       200:
+ *         description: Consent details
+ *       404:
+ *         description: Consent not found
+ */
+router.get('/:consentId', getDomesticPaymentConsent);
+
+/**
+ * @swagger
+ * /domestic-payment-consents/{consentId}/funds-confirmation:
+ *   get:
+ *     summary: Get funds confirmation
+ *     description: Checks if funds are available for the payment consent
+ *     parameters:
+ *       - in: path
+ *         name: consentId
+ *         required: true
+ *         description: ID of the consent to check funds for
+ *     responses:
+ *       200:
+ *         description: Funds confirmation result
+ *       404:
+ *         description: Consent not found
+ */
+router.get('/:consentId/funds-confirmation', getDomesticPaymentConsentFundsConfirmation);
+
+export default router;

--- a/tyk-bank/src/uk/payment-initiation/routes/payments.ts
+++ b/tyk-bank/src/uk/payment-initiation/routes/payments.ts
@@ -1,0 +1,68 @@
+import { Router } from 'express';
+import { 
+  createDomesticPayment, 
+  getDomesticPayment,
+  getDomesticPaymentDetails
+} from '../controllers/payments';
+
+const router = Router();
+
+/**
+ * @swagger
+ * /domestic-payments:
+ *   post:
+ *     summary: Create domestic payment
+ *     description: Creates a new domestic payment
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/DomesticPaymentRequest'
+ *     responses:
+ *       201:
+ *         description: Payment created successfully
+ *       400:
+ *         description: Invalid request
+ */
+router.post('/', createDomesticPayment);
+
+/**
+ * @swagger
+ * /domestic-payments/{paymentId}:
+ *   get:
+ *     summary: Get domestic payment
+ *     description: Retrieves domestic payment details by ID
+ *     parameters:
+ *       - in: path
+ *         name: paymentId
+ *         required: true
+ *         description: ID of the payment to retrieve
+ *     responses:
+ *       200:
+ *         description: Payment details
+ *       404:
+ *         description: Payment not found
+ */
+router.get('/:paymentId', getDomesticPayment);
+
+/**
+ * @swagger
+ * /domestic-payments/{paymentId}/payment-details:
+ *   get:
+ *     summary: Get payment details
+ *     description: Retrieves additional payment details by ID
+ *     parameters:
+ *       - in: path
+ *         name: paymentId
+ *         required: true
+ *         description: ID of the payment to retrieve details for
+ *     responses:
+ *       200:
+ *         description: Payment details
+ *       404:
+ *         description: Payment not found
+ */
+router.get('/:paymentId/payment-details', getDomesticPaymentDetails);
+
+export default router;

--- a/tyk-bank/src/uk/payment-initiation/server.ts
+++ b/tyk-bank/src/uk/payment-initiation/server.ts
@@ -1,14 +1,12 @@
 import express, { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import morgan from 'morgan';
-import accountsRoutes from './routes/accounts';
 import consentsRoutes from './routes/consents';
-import { getBalances } from './controllers/balances';
-import { getTransactions } from './controllers/transactions';
+import paymentsRoutes from './routes/payments';
 
 // Create Express app
 const app = express();
-const PORT = process.env.PORT || 3001; // Changed to 3001
+const PORT = process.env.PORT || 3002; // Using 3002 for payment-initiation API
 
 // Middleware
 app.use(cors());
@@ -34,25 +32,22 @@ app.get('/health', (req: Request, res: Response) => {
 });
 
 // API routes
-app.use('/account-access-consents', consentsRoutes);
-app.use('/accounts', accountsRoutes);
-app.get('/balances', getBalances);
-app.get('/transactions', getTransactions);
+app.use('/domestic-payment-consents', consentsRoutes);
+app.use('/domestic-payments', paymentsRoutes);
 
 // Root endpoint with API information
 app.get('/', (req: Request, res: Response) => {
   res.status(200).json({
-    name: 'Tyk Bank - Open Banking Mock Implementation - UK Account Information API',
+    name: 'Tyk Bank - Open Banking Mock Implementation - UK Payment Initiation API',
     version: '1.0.0',
-    description: 'Mock implementation of the UK Open Banking Account Information API',
+    description: 'Mock implementation of the UK Open Banking Payment Initiation API',
     endpoints: [
-      '/account-access-consents',
-      '/accounts',
-      '/accounts/{accountId}',
-      '/accounts/{accountId}/balances',
-      '/accounts/{accountId}/transactions',
-      '/balances',
-      '/transactions'
+      '/domestic-payment-consents',
+      '/domestic-payment-consents/{ConsentId}',
+      '/domestic-payment-consents/{ConsentId}/funds-confirmation',
+      '/domestic-payments',
+      '/domestic-payments/{DomesticPaymentId}',
+      '/domestic-payments/{DomesticPaymentId}/payment-details'
     ]
   });
 });
@@ -75,9 +70,11 @@ app.use((req: Request, res: Response) => {
 });
 
 // Start server
-app.listen(PORT, () => {
-  console.log(`Tyk Bank Open Banking - UK Account Information API running on port ${PORT}`);
-  console.log(`Server URL: http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Tyk Bank Open Banking - UK Payment Initiation API running on port ${PORT}`);
+    console.log(`Server URL: http://localhost:${PORT}`);
+  });
+}
 
 export default app;


### PR DESCRIPTION
…ayments

This commit adds a new microservice for the tyk-bank mock implementation that implements the UK Open Banking Payment Initiation API, focusing on domestic payments. The implementation follows the same architectural pattern as the existing account-information API.

Key changes:
- Add models, data layer, controllers, and routes for domestic payment consents and payments
- Create server configuration for the payment-initiation API
- Update package.json with new scripts for running the payment-initiation API
- Update README.md with information about the new API
- Update docker-compose.yml to include the payment-initiation service
- Update Dockerfile to support the payment-initiation API

The implementation includes endpoints for:
- Creating and retrieving domestic payment consents
- Checking funds availability
- Creating and retrieving domestic payments
- Retrieving payment details